### PR TITLE
fix: remove special characters from RDS password generation

### DIFF
--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -60,5 +60,8 @@ data "aws_secretsmanager_secret_version" "db_credentials" {
 resource "random_password" "db_password" {
   count   = var.create_resources ? 1 : 0
   length  = 16
-  special = true
+  special = false
+  upper   = true
+  lower   = true
+  numeric = true
 } 


### PR DESCRIPTION
- Changed random_password special = false to avoid AWS RDS invalid characters
- Added upper, lower, numeric = true for strong password generation
- Fixes 'InvalidParameterValue: MasterUserPassword is not a valid password' error