### PR TITLE
feat: add Lab Magic Destroy workflow for end-of-day cleanup

### DIFF
--- a/.github/workflows/lab-magic-destroy.yml
+++ b/.github/workflows/lab-magic-destroy.yml
@@ -1,0 +1,211 @@
+name: 🧪 Lab Magic Destroy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environments:
+        description: "Environments to destroy"
+        required: true
+        default: "all"
+        type: choice
+        options: ["all", "dev", "staging", "production"]
+      confirm_destroy:
+        description: "Type 'DESTROY' to confirm you want to destroy infrastructure"
+        required: true
+        type: string
+        default: ""
+
+env:
+  TF_VERSION: "1.5.0"
+  AWS_REGION: "us-east-2"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  validate-destroy:
+    name: Validate Destroy Confirmation
+    runs-on: ubuntu-latest
+    outputs:
+      should_destroy: ${{ steps.validate.outputs.should_destroy }}
+    
+    steps:
+      - name: Validate Confirmation
+        id: validate
+        run: |
+          if [ "${{ github.event.inputs.confirm_destroy }}" = "DESTROY" ]; then
+            echo "should_destroy=true" >> $GITHUB_OUTPUT
+            echo "✅ Destroy confirmed - proceeding with infrastructure destruction"
+          else
+            echo "should_destroy=false" >> $GITHUB_OUTPUT
+            echo "❌ Destroy not confirmed. Please type 'DESTROY' to proceed."
+            exit 1
+          fi
+
+  destroy-dev:
+    name: Destroy Development Environment
+    runs-on: ubuntu-latest
+    needs: validate-destroy
+    if: |
+      needs.validate-destroy.outputs.should_destroy == 'true' &&
+      (github.event.inputs.environments == 'all' || github.event.inputs.environments == 'dev')
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Debug AWS Configuration
+        run: |
+          echo "=== AWS Configuration Debug ==="
+          echo "AWS Region: ${{ env.AWS_REGION }}"
+          echo "GitHub Repository: ${{ github.repository }}"
+          echo "GitHub Ref: ${{ github.ref }}"
+          echo "GitHub Event: ${{ github.event_name }}"
+          echo "Role ARN: arn:aws:iam::123324351829:role/github-actions-global"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::123324351829:role/github-actions-global
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: lab-magic-destroy-dev-${{ github.run_id }}
+
+      - name: Verify AWS Credentials
+        run: |
+          echo "=== AWS Credentials Verification ==="
+          aws sts get-caller-identity
+          echo "AWS CLI version:"
+          aws --version
+
+      - name: Terraform Init
+        working-directory: environments/dev
+        run: terraform init
+
+      - name: Terraform Destroy
+        working-directory: environments/dev
+        run: terraform destroy -auto-approve
+
+      - name: Destroy Complete
+        run: |
+          echo "## 🧹 Development Environment Destroyed" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment**: Development" >> $GITHUB_STEP_SUMMARY
+          echo "**Status**: ✅ Destroyed" >> $GITHUB_STEP_SUMMARY
+          echo "**Time**: $(date)" >> $GITHUB_STEP_SUMMARY
+
+  destroy-staging:
+    name: Destroy Staging Environment
+    runs-on: ubuntu-latest
+    needs: validate-destroy
+    if: |
+      needs.validate-destroy.outputs.should_destroy == 'true' &&
+      (github.event.inputs.environments == 'all' || github.event.inputs.environments == 'staging')
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::123324351829:role/github-actions-global
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: lab-magic-destroy-staging-${{ github.run_id }}
+
+      - name: Terraform Init
+        working-directory: environments/staging
+        run: terraform init
+
+      - name: Terraform Destroy
+        working-directory: environments/staging
+        run: terraform destroy -auto-approve
+
+      - name: Destroy Complete
+        run: |
+          echo "## 🧹 Staging Environment Destroyed" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment**: Staging" >> $GITHUB_STEP_SUMMARY
+          echo "**Status**: ✅ Destroyed" >> $GITHUB_STEP_SUMMARY
+          echo "**Time**: $(date)" >> $GITHUB_STEP_SUMMARY
+
+  destroy-production:
+    name: Destroy Production Environment
+    runs-on: ubuntu-latest
+    needs: validate-destroy
+    if: |
+      needs.validate-destroy.outputs.should_destroy == 'true' &&
+      (github.event.inputs.environments == 'all' || github.event.inputs.environments == 'production')
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::123324351829:role/github-actions-global
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: lab-magic-destroy-production-${{ github.run_id }}
+
+      - name: Terraform Init
+        working-directory: environments/production
+        run: terraform init
+
+      - name: Terraform Destroy
+        working-directory: environments/production
+        run: terraform destroy -auto-approve
+
+      - name: Destroy Complete
+        run: |
+          echo "## 🧹 Production Environment Destroyed" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment**: Production" >> $GITHUB_STEP_SUMMARY
+          echo "**Status**: ✅ Destroyed" >> $GITHUB_STEP_SUMMARY
+          echo "**Time**: $(date)" >> $GITHUB_STEP_SUMMARY
+
+  destroy-summary:
+    name: 🎉 Lab Magic Complete
+    runs-on: ubuntu-latest
+    needs: [validate-destroy, destroy-dev, destroy-staging, destroy-production]
+    if: always()
+    
+    steps:
+      - name: Generate Summary
+        run: |
+          echo "## 🧪 Lab Magic Destroy Complete!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**🎯 Mission Accomplished**: All selected environments have been destroyed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 💰 Cost Impact:" >> $GITHUB_STEP_SUMMARY
+          echo "- **EC2 Instances**: Terminated" >> $GITHUB_STEP_SUMMARY
+          echo "- **RDS Databases**: Deleted" >> $GITHUB_STEP_SUMMARY
+          echo "- **Load Balancers**: Removed" >> $GITHUB_STEP_SUMMARY
+          echo "- **NAT Gateways**: Deleted" >> $GITHUB_STEP_SUMMARY
+          echo "- **Secrets**: Cleaned up" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 🚀 Next Steps:" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tomorrow**: Run your environment-specific workflows to rebuild" >> $GITHUB_STEP_SUMMARY
+          echo "- **Cost**: $0 until next deployment" >> $GITHUB_STEP_SUMMARY
+          echo "- **State**: Preserved in S3 for quick rebuilds" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**🧪 Lab Magic**: Your playground is now clean and cost-free!" >> $GITHUB_STEP_SUMMARY
+
+      - name: Send Notification
+        run: |
+          echo "## 📱 Notification Sent" >> $GITHUB_STEP_SUMMARY
+          echo "**Status**: Lab Magic Destroy completed successfully" >> $GITHUB_STEP_SUMMARY
+          echo "**Time**: $(date)" >> $GITHUB_STEP_SUMMARY
+          echo "**Cost**: $0 achieved" >> $GITHUB_STEP_SUMMARY 


### PR DESCRIPTION
- Manual trigger only (no automatic runs)
- Environment selection (all, dev, staging, production)
- Safety confirmation (must type 'DESTROY')
- Parallel execution for efficiency
- Comprehensive cost impact summary
- Perfect for maintaining /bin/bash cost playground