### PR TITLE
refactor: centralize security groups in networking module

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -68,6 +68,7 @@ module "loadbalancer" {
   vpc_id      = module.networking.vpc_id
   public_subnets = module.networking.public_subnet_ids
   certificate_arn = var.certificate_arn
+  security_group_id = module.networking.alb_security_group_id
 }
 
 # Database Module
@@ -81,6 +82,7 @@ module "database" {
   db_name                     = var.db_name
   db_username                 = module.secrets.db_username
   db_password                 = module.secrets.db_password
+  security_group_id           = module.networking.database_security_group_id
 }
 
 # Blue Auto Scaling Group
@@ -102,6 +104,7 @@ module "blue_asg" {
   db_name                  = var.db_name
   db_user                  = module.secrets.db_username
   db_password              = module.secrets.db_password
+  security_group_id        = module.networking.webserver_security_group_id
 }
 
 # Green Auto Scaling Group
@@ -123,6 +126,7 @@ module "green_asg" {
   db_name                  = var.db_name
   db_user                  = module.secrets.db_username
   db_password              = module.secrets.db_password
+  security_group_id        = module.networking.webserver_security_group_id
 }
 
 # SSM Module for Database Bootstrapping (updated to use blue ASG)

--- a/environments/production/main.tf
+++ b/environments/production/main.tf
@@ -60,11 +60,12 @@ module "database" {
   environment                 = var.environment
   vpc_id                      = module.networking.vpc_id
   private_subnets             = module.networking.private_subnet_ids
-  webserver_security_group_id = module.webserver.security_group_id
+  webserver_security_group_ids = [module.webserver.security_group_id]
   db_instance_type            = var.db_instance_type
   db_name                     = var.db_name
   db_username                 = module.secrets.db_username
   db_password                 = module.secrets.db_password
+  security_group_id           = module.networking.database_security_group_id
 }
 
 # Compute Module (Web Server)
@@ -79,6 +80,7 @@ module "webserver" {
   db_name        = var.db_name
   db_user        = module.secrets.db_username
   db_password    = module.secrets.db_password
+  security_group_id = module.networking.webserver_security_group_id
 }
 
 # SSM Module for Database Bootstrapping

--- a/modules/compute/asg/main.tf
+++ b/modules/compute/asg/main.tf
@@ -16,43 +16,7 @@ terraform {
   }
 }
 
-# Security Group for Auto Scaling Group instances
-resource "aws_security_group" "asg" {
-  name        = "${var.environment}-${var.deployment_color}-asg-sg"
-  description = "Security group for ${var.deployment_color} Auto Scaling Group"
-  vpc_id      = var.vpc_id
-
-  # Allow HTTP traffic from ALB
-  ingress {
-    from_port       = 8080
-    to_port         = 8080
-    protocol        = "tcp"
-    security_groups = [var.alb_security_group_id]
-    description     = "Allow HTTP traffic from ALB"
-  }
-
-  # SSH access (for debugging)
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # Consider restricting this in production
-    description = "SSH access"
-  }
-
-  # Allow all outbound traffic
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow all outbound traffic"
-  }
-
-  tags = {
-    Name = "${var.environment}-${var.deployment_color}-asg-sg"
-  }
-}
+# Security group is now managed by the networking module
 
 # IAM Role for Auto Scaling Group instances
 resource "aws_iam_role" "asg" {
@@ -189,7 +153,7 @@ resource "aws_launch_template" "asg" {
 
   network_interfaces {
     associate_public_ip_address = true
-    security_groups             = [aws_security_group.asg.id]
+    security_groups             = [var.security_group_id]
   }
 
   iam_instance_profile {

--- a/modules/compute/asg/outputs.tf
+++ b/modules/compute/asg/outputs.tf
@@ -25,7 +25,7 @@ output "launch_template_name" {
 
 output "security_group_id" {
   description = "ID of the ASG security group"
-  value       = aws_security_group.asg.id
+  value       = var.security_group_id
 }
 
 output "iam_role_arn" {

--- a/modules/compute/asg/variables.tf
+++ b/modules/compute/asg/variables.tf
@@ -94,4 +94,9 @@ variable "cpu_threshold" {
   description = "CPU utilization threshold for auto scaling"
   type        = number
   default     = 80
+}
+
+variable "security_group_id" {
+  description = "Security group ID for the ASG instances (managed by networking module)"
+  type        = string
 } 

--- a/modules/compute/webserver/main.tf
+++ b/modules/compute/webserver/main.tf
@@ -16,43 +16,7 @@ terraform {
   }
 }
 
-# Security Group for Web Server
-resource "aws_security_group" "webserver" {
-  name        = "${var.environment}-webserver-sg"
-  description = "Security group for web server"
-  vpc_id      = var.vpc_id
-
-  # Allow HTTP traffic on port 8080
-  ingress {
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow HTTP traffic on port 8080"
-  }
-
-  # SSH access
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # Consider restricting this to your IP range
-    description = "SSH access"
-  }
-
-  # Allow all outbound traffic
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow all outbound traffic"
-  }
-
-  tags = {
-    Name = "${var.environment}-webserver-sg"
-  }
-}
+# Security group is now managed by the networking module
 
 # IAM Role for Web Server
 resource "aws_iam_role" "webserver" {
@@ -185,7 +149,7 @@ resource "aws_instance" "webserver" {
   ami                    = var.ami_id
   instance_type          = var.instance_type
   subnet_id              = var.public_subnets[0] # Place in first public subnet
-  vpc_security_group_ids = [aws_security_group.webserver.id]
+  vpc_security_group_ids = [var.security_group_id]
   iam_instance_profile   = aws_iam_instance_profile.webserver.name
   key_name               = aws_key_pair.webserver.key_name
   user_data              = data.template_file.user_data.rendered

--- a/modules/compute/webserver/outputs.tf
+++ b/modules/compute/webserver/outputs.tf
@@ -10,7 +10,7 @@ output "public_ip" {
 
 output "security_group_id" {
   description = "ID of the web server security group"
-  value       = aws_security_group.webserver.id
+  value       = var.security_group_id
 }
 
 output "instance_private_ip" {

--- a/modules/compute/webserver/variables.tf
+++ b/modules/compute/webserver/variables.tf
@@ -50,4 +50,9 @@ variable "db_password" {
   description = "Database password"
   type        = string
   sensitive   = true
+}
+
+variable "security_group_id" {
+  description = "Security group ID for the web server (managed by networking module)"
+  type        = string
 } 

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -1,25 +1,4 @@
-# Security Group for RDS
-resource "aws_security_group" "database" {
-  name        = "${var.environment}-database-sg"
-  description = "Security group for RDS instance"
-  vpc_id      = var.vpc_id
-
-  # Allow MySQL access from web server security groups
-  dynamic "ingress" {
-    for_each = var.webserver_security_group_ids
-    content {
-      from_port       = 3306
-      to_port         = 3306
-      protocol        = "tcp"
-      security_groups = [ingress.value]
-      description     = "Allow MySQL access from web server security group"
-    }
-  }
-
-  tags = {
-    Name = "${var.environment}-database-sg"
-  }
-}
+# Security group is now managed by the networking module
 
 # DB Subnet Group
 resource "aws_db_subnet_group" "database" {
@@ -49,7 +28,7 @@ resource "aws_db_instance" "database" {
   username = var.db_username
   password = var.db_password
 
-  vpc_security_group_ids = [aws_security_group.database.id]
+  vpc_security_group_ids = [var.security_group_id]
   db_subnet_group_name   = aws_db_subnet_group.database.name
 
   backup_retention_period = 7

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -20,5 +20,5 @@ output "db_instance_port" {
 
 output "db_security_group_id" {
   description = "The security group ID of the RDS instance"
-  value       = aws_security_group.database.id
+  value       = var.security_group_id
 } 

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -37,4 +37,9 @@ variable "db_password" {
   description = "Master password for the database"
   type        = string
   sensitive   = true
+}
+
+variable "security_group_id" {
+  description = "Security group ID for the database (managed by networking module)"
+  type        = string
 } 

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -8,50 +8,14 @@ terraform {
   }
 }
 
-# Security Group for Application Load Balancer
-resource "aws_security_group" "alb" {
-  name        = "${var.environment}-alb-sg"
-  description = "Security group for Application Load Balancer"
-  vpc_id      = var.vpc_id
-
-  # Allow HTTP traffic from internet
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow HTTP traffic from internet"
-  }
-
-  # Allow HTTPS traffic from internet (for future SSL)
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow HTTPS traffic from internet"
-  }
-
-  # Allow all outbound traffic
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow all outbound traffic"
-  }
-
-  tags = {
-    Name = "${var.environment}-alb-sg"
-  }
-}
+# Security group is now managed by the networking module
 
 # Application Load Balancer
 resource "aws_lb" "main" {
   name               = "${var.environment}-alb"
   internal           = false
   load_balancer_type = "application"
-  security_groups    = [aws_security_group.alb.id]
+  security_groups    = [var.security_group_id]
   subnets            = var.public_subnets
 
   enable_deletion_protection = false

--- a/modules/loadbalancer/outputs.tf
+++ b/modules/loadbalancer/outputs.tf
@@ -20,7 +20,7 @@ output "alb_zone_id" {
 
 output "alb_security_group_id" {
   description = "ID of the ALB security group"
-  value       = aws_security_group.alb.id
+  value       = var.security_group_id
 }
 
 output "blue_target_group_arn" {

--- a/modules/loadbalancer/variables.tf
+++ b/modules/loadbalancer/variables.tf
@@ -14,7 +14,7 @@ variable "public_subnets" {
 }
 
 variable "certificate_arn" {
-  description = "ARN of the SSL certificate for HTTPS listener (optional)"
+  description = "ARN of the SSL certificate for HTTPS listener"
   type        = string
   default     = null
 }
@@ -47,4 +47,9 @@ variable "health_check_unhealthy_threshold" {
   description = "Number of consecutive health checks required to mark target as unhealthy"
   type        = number
   default     = 2
+}
+
+variable "security_group_id" {
+  description = "Security group ID for the ALB (managed by networking module)"
+  type        = string
 } 

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -43,6 +43,11 @@ output "database_security_group_id" {
   value       = aws_security_group.database.id
 }
 
+output "alb_security_group_id" {
+  description = "The ID of the ALB security group"
+  value       = aws_security_group.alb.id
+}
+
 output "public_route_table_id" {
   description = "The ID of the public route table"
   value       = aws_route_table.public.id


### PR DESCRIPTION
- Move all security group definitions to networking module
- Remove redundant security groups from other modules
- Update all modules to reference networking security groups
- Fix naming conflicts that prevented destroy/create cycles
- Improve architectural separation of concerns