### PR TITLE
fix: Add missing CloudWatch Logs tag permissions for Terraform CI/CD

### DIFF
--- a/modules/oidc/main.tf
+++ b/modules/oidc/main.tf
@@ -222,6 +222,21 @@ resource "aws_iam_role_policy" "terraform_permissions" {
           "cloudwatch:*"
         ]
         Resource = "*"
+      },
+      # CloudWatch Logs permissions for Terraform and Lambda
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:DescribeLogGroups",
+          "logs:CreateLogGroup",
+          "logs:PutRetentionPolicy",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:ListTagsForResource",
+          "logs:TagResource",
+          "logs:UntagResource"
+        ]
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
- Add logs:ListTagsForResource, logs:TagResource, logs:UntagResource to GitHub Actions IAM policy
- Ensures Terraform can manage and tag log groups in CI/CD workflows
- Follows least-privilege principle for log group operations