### PR TITLE
fix: Add cleanup-logs-lambda role pattern to IAM permissions

### DIFF
--- a/modules/oidc/main.tf
+++ b/modules/oidc/main.tf
@@ -170,6 +170,7 @@ resource "aws_iam_role_policy" "terraform_permissions" {
           "arn:aws:iam::*:role/dev-*",
           "arn:aws:iam::*:role/prod-*",
           "arn:aws:iam::*:role/production-*",
+          "arn:aws:iam::*:role/cleanup-logs-lambda-*",
           "arn:aws:iam::*:policy/tf-playground-*",
           "arn:aws:iam::*:policy/staging-*",
           "arn:aws:iam::*:policy/dev-*",


### PR DESCRIPTION
- Add arn:aws:iam::*:role/cleanup-logs-lambda-* to IAM role permissions
- Fixes destroy process failure for cleanup-logs-lambda-staging role
- Ensures CI/CD can manage Lambda cleanup roles across environments