### PR TITLE
Fix comment-triggered terraform plan formatting and platform detection

### DIFF
--- a/.github/workflows/staging-terraform.yml
+++ b/.github/workflows/staging-terraform.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Terraform Plan
         working-directory: environments/terraform
         run: |
-          terraform plan -var-file=${{ steps.comment-check.outputs.tfvars_file }}
+          terraform plan -var-file=${{ steps.comment-check.outputs.tfvars_file }} -out=comment-plan.tfplan
         continue-on-error: true
 
       - name: Comment Plan Results
@@ -142,7 +142,7 @@ jobs:
             **Environment**: Staging`;
             
             try {
-              const plan = execSync('cd environments/terraform && terraform show', { encoding: 'utf8' });
+              const plan = execSync('cd environments/terraform && terraform show comment-plan.tfplan', { encoding: 'utf8' });
               const cleanPlan = plan.replace(/\x1b\[[0-9;]*m/g, '');
               
               comment += `
@@ -172,7 +172,7 @@ jobs:
             });
 
   terraform-plan:
-    name: Terraform Plan
+    name: Terraform Plan (Auto)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     
@@ -295,20 +295,33 @@ jobs:
             # Auto-detect platform from current Terraform state
             echo "**Source**: Auto-detected from Terraform state" >> $GITHUB_STEP_SUMMARY
             
-            # Check for EKS cluster in outputs
-            if terraform output eks_cluster_name >/dev/null 2>&1; then
-              PLATFORM="eks"
-              CLUSTER_NAME=$(terraform output -raw eks_cluster_name)
-              echo "**EKS Cluster Found**: $CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
-            # Check for ECS cluster in outputs  
-            elif terraform output ecs_cluster_name >/dev/null 2>&1; then
+            # Check if state has any resources first
+            RESOURCE_COUNT=$(terraform state list 2>/dev/null | wc -l)
+            if [ "$RESOURCE_COUNT" -eq 0 ]; then
               PLATFORM="ecs"
-              CLUSTER_NAME=$(terraform output -raw ecs_cluster_name)
-              echo "**ECS Cluster Found**: $CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+              echo "**Empty State**: Defaulting to ECS for new deployment" >> $GITHUB_STEP_SUMMARY
             else
-              # Default to ECS for new deployments
-              PLATFORM="ecs"
-              echo "**No clusters found**: Defaulting to ECS for new deployment" >> $GITHUB_STEP_SUMMARY
+              # Check for EKS cluster in outputs
+              if terraform output eks_cluster_name >/dev/null 2>&1; then
+                PLATFORM="eks"
+                CLUSTER_NAME=$(terraform output -raw eks_cluster_name)
+                echo "**EKS Cluster Found**: $CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+              # Check for ECS cluster in outputs  
+              elif terraform output ecs_cluster_name >/dev/null 2>&1; then
+                PLATFORM="ecs"
+                CLUSTER_NAME=$(terraform output -raw ecs_cluster_name)
+                echo "**ECS Cluster Found**: $CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+              else
+                # Check for Lambda functions (serverless)
+                if terraform state list 2>/dev/null | grep -q "aws_lambda_function"; then
+                  PLATFORM="serverless"
+                  echo "**Lambda Functions Found**: Detected serverless deployment" >> $GITHUB_STEP_SUMMARY
+                else
+                  # Default to ECS
+                  PLATFORM="ecs"
+                  echo "**No specific platform detected**: Defaulting to ECS" >> $GITHUB_STEP_SUMMARY
+                fi
+              fi
             fi
           fi
           


### PR DESCRIPTION
## Summary
- Fix ANSI color codes appearing in GitHub PR comments by using plan file output
- Improve platform detection to handle empty state without warnings  
- Add serverless platform detection via Lambda function detection
- Rename auto plan job to distinguish from comment-triggered plans
- Ensure comment-triggered plans use correct platform without interference

## Test plan
- [ ] Comment `/plan serverless` to test serverless platform selection
- [ ] Comment `/plan ecs` to test ECS platform selection
- [ ] Comment `/plan eks` to test EKS platform selection
- [ ] Verify clean formatting without ANSI color codes in PR comments

🤖 Generated with [Claude Code](https://claude.ai/code)