### PR TITLE
Modernize secrets management and establish shared services hub

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -222,7 +222,7 @@ class Settings:
         try:
             region = os.environ.get('AWS_REGION', 'us-east-2')
             client = boto3.client('ssm', region_name=region)
-            parameter_name = '/tf-playground/all/db-pword'
+            parameter_name = '/tf-playground/all/db-password'
             response = client.get_parameter(
                 Name=parameter_name,
                 WithDecryption=True

--- a/docs/SHARED-SERVICES.md
+++ b/docs/SHARED-SERVICES.md
@@ -1,0 +1,185 @@
+# Shared Services Architecture
+
+## Overview
+
+terraform-playground serves a **dual purpose**:
+1. **Playground Environment**: Experimental infrastructure and learning space
+2. **Shared Services Hub**: Central management of shared infrastructure components
+
+This document outlines the shared services managed by terraform-playground that are consumed by other projects.
+
+## Architecture Philosophy
+
+- **Central Management**: Shared resources are defined once and consumed by multiple projects
+- **Security Through Centralization**: IAM roles and sensitive parameters managed in one place
+- **Cost Efficiency**: Avoid duplicating resources across projects
+- **Simplified Maintenance**: Update shared components in one location
+
+## Shared Services Components
+
+### 1. GitHub Actions OIDC Provider & IAM Role
+
+**Resource**: `github-actions-global` IAM Role  
+**Location**: `environments/global/main.tf`  
+**Module**: `modules/oidc/main.tf`
+
+The global OIDC provider and IAM role enable GitHub Actions workflows across multiple repositories to authenticate with AWS without storing credentials.
+
+**Consuming Projects**:
+- virtualexponent-website
+- curriculum-designer
+- project-glish
+- terraform-playground (self)
+
+**Permissions Scope**:
+- Terraform state management (S3 + DynamoDB)
+- SSM Parameter Store access (`/global/*` and environment-specific)
+- EC2, ECS, EKS, Lambda deployment capabilities
+- CloudWatch logging and monitoring
+- Secrets Manager access
+
+### 2. SSM Parameter Store - Shared Secrets
+
+**Namespace**: `/global/*`  
+**Example**: `/global/claude-code/api-key`
+
+Shared parameters that multiple projects need access to are stored under the `/global/` namespace.
+
+**Current Parameters**:
+- `/global/claude-code/api-key` - Anthropic API key for Claude Code reviews
+
+**Access Pattern**:
+```yaml
+# In GitHub Actions workflow
+- name: Get Claude API Key
+  run: |
+    API_KEY=$(aws ssm get-parameter \
+      --name /global/claude-code/api-key \
+      --with-decryption \
+      --query 'Parameter.Value' \
+      --output text)
+```
+
+### 3. ECR Repository (Global)
+
+**Resource**: `global-tf-pg-ecr`  
+**Purpose**: Shared container registry for all environments
+
+While primarily used by terraform-playground, this ECR repository is available for other projects that need container storage in the same AWS account.
+
+### 4. CloudWatch Log Groups
+
+**Location**: `modules/log-groups/`  
+**Purpose**: Centralized log management structure
+
+Provides consistent log group naming and retention policies across environments.
+
+### 5. WAF (Web Application Firewall)
+
+**Location**: `modules/waf/`  
+**Status**: Available for attachment to any ALB/CloudFront distribution
+
+Shared WAF rules and IP sets that can protect multiple applications.
+
+## Adding New Shared Services
+
+When adding a new shared service:
+
+1. **Determine Scope**: Is this truly shared across projects or project-specific?
+2. **Add to Global Environment**: Update `environments/global/main.tf`
+3. **Document Here**: Add the service to this document
+4. **Update IAM Permissions**: Ensure `github-actions-global` role has necessary permissions
+5. **Test Access**: Verify consuming projects can access the resource
+
+## Security Considerations
+
+### Principle of Least Privilege
+While `github-actions-global` has broad permissions for convenience, consider:
+- Resources are scoped by naming patterns (e.g., `tf-playground-*`)
+- SSM parameters are scoped by path (`/global/*`, `/${environment}/*`)
+- KMS decryption is limited to SSM service context
+
+### Secrets Management
+- All sensitive values use SSM SecureString parameters
+- Terraform ignores changes to secret values via lifecycle rules
+- Secrets are never committed to git
+
+### Audit Trail
+- All shared resources are tagged with:
+  - `ManagedBy: terraform`
+  - `Project: shared-infrastructure`
+  - `Environment: global`
+- CloudTrail logs all API calls for audit purposes
+
+## Project Integration Guide
+
+### For New Projects Using Shared Services:
+
+1. **Configure AWS Provider** with us-east-2 region:
+```hcl
+provider "aws" {
+  region = "us-east-2"
+}
+```
+
+2. **Set up GitHub Actions** with OIDC:
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - name: Configure AWS credentials
+    uses: aws-actions/configure-aws-credentials@v4
+    with:
+      role-to-assume: arn:aws:iam::123324351829:role/github-actions-global
+      aws-region: us-east-2
+```
+
+3. **Access Shared Parameters**:
+```bash
+aws ssm get-parameter \
+  --name /global/parameter-name \
+  --with-decryption \
+  --region us-east-2
+```
+
+## Future Enhancements
+
+### Planned Improvements:
+1. **Project-Specific IAM Roles**: Create per-project roles with scoped permissions
+2. **Parameter Hierarchy**: Implement `/global/project-name/*` structure
+3. **Cross-Account Access**: Support for multi-account architectures
+4. **Service Catalog**: Pre-approved infrastructure patterns
+
+### Under Consideration:
+- Centralized VPC with shared subnets
+- Shared RDS Aurora cluster for development databases
+- Global CloudFront distribution with origin failover
+- Centralized logging with OpenSearch
+
+## Maintenance
+
+### Regular Tasks:
+- Review IAM permissions quarterly
+- Rotate shared secrets annually
+- Clean up unused parameters monthly
+- Audit resource tags for consistency
+
+### Breaking Changes:
+When making breaking changes to shared services:
+1. Announce in all consuming project channels
+2. Provide migration timeline (minimum 2 weeks)
+3. Support parallel old/new versions during transition
+4. Document migration steps
+
+## Contact
+
+**Primary Maintainer**: terraform-playground repository owner  
+**Issues**: Create issue in terraform-playground repository  
+**Emergency**: Check CloudWatch alarms and logs first
+
+---
+
+*Last Updated*: 2025-08-29  
+*Version*: 1.0.0

--- a/docs/portfolio/2025-08-29-secrets-modernization.md
+++ b/docs/portfolio/2025-08-29-secrets-modernization.md
@@ -1,0 +1,156 @@
+---
+title: "Modernizing Secrets Management: From SSH Keys to Session Manager"
+date: 2025-08-29T12:00:00-03:00
+draft: false
+tags: ["AWS", "Infrastructure", "Security", "DevOps", "terraform-playground"]
+categories: ["Infrastructure Modernization"]
+series: ["terraform-playground Evolution"]
+toc: true
+summary: "How I eliminated SSH key management overhead and consolidated secrets management in terraform-playground, reducing attack surface while improving developer experience."
+---
+
+## The Problem I Faced
+
+While auditing terraform-playground's shared services architecture, I discovered technical debt that had accumulated over time:
+
+- **Four deprecated secrets** still existed in AWS Secrets Manager ($0.40/month each)
+- **SSH keys** were being fetched but never used (we'd migrated to SSM Session Manager)
+- **Duplicate database passwords** in both Secrets Manager and Parameter Store
+- **Legacy IAM permissions** granting access to non-existent resources
+
+The code was trying to be "graceful" about missing resources, but it wasn't truly graceful - it would fail during Terraform runs if the secrets didn't exist.
+
+## My Solution Approach
+
+### 1. Investigation Phase
+
+First, I needed to understand what was actually being used versus what was legacy:
+
+```bash
+# Found these secrets in AWS but not being used
+/tf-playground/all/ssh-key          # Deprecated - using SSM now
+/tf-playground/all/ssh-key-public   # Deprecated - using SSM now  
+/tf-playground/all/db-pword         # Old parameter name
+/tf-playground/dev/database/credentials  # Never actually used
+```
+
+### 2. Understanding the "Why"
+
+Before removing anything, I researched why these weren't needed:
+
+- **ECS Fargate**: Serverless containers - no SSH needed, use `aws ecs execute-command`
+- **EKS**: Access pods via `kubectl exec`, nodes via SSM if needed
+- **EC2/ASG**: Session Manager replaced SSH entirely
+
+This wasn't just cleanup - it was embracing AWS's modern security practices.
+
+### 3. The Migration
+
+I systematically updated each component:
+
+#### Infrastructure Code (Terraform)
+```hcl
+# BEFORE: Fetching unused SSH keys
+data "aws_secretsmanager_secret" "ssh_private" {
+  name = local.ssh_private_key_secret_name
+}
+
+# AFTER: Clean removal with documentation
+# SSH keys removed - not needed for any platform:
+# - EC2/ASG: Uses SSM Session Manager (aws ssm start-session)
+# - ECS Fargate: Serverless, use ECS Exec (aws ecs execute-command)
+# - EKS: Use kubectl exec for pods, SSM for nodes if needed
+```
+
+#### IAM Permissions Evolution
+```hcl
+# BEFORE: Broad Secrets Manager access
+{
+  Action = ["secretsmanager:GetSecretValue"]
+  Resource = ["arn:aws:secretsmanager:*:*:secret:/tf-playground/*"]
+}
+
+# AFTER: Specific Parameter Store access with KMS
+{
+  Action = ["ssm:GetParameter", "ssm:GetParameters"]
+  Resource = ["arn:aws:ssm:*:*:parameter/tf-playground/all/db-password"]
+},
+{
+  Action = ["kms:Decrypt"]
+  Resource = "*"
+  Condition = {
+    StringEquals = {
+      "kms:ViaService" = "ssm.${region}.amazonaws.com"
+    }
+  }
+}
+```
+
+### 4. Script Modernization
+
+Updated all database scripts to use Parameter Store:
+
+```bash
+# BEFORE: Using Secrets Manager
+DB_PASSWORD=$(aws secretsmanager get-secret-value \
+  --secret-id "/tf-playground/all/db-pword" \
+  --query 'SecretString' --output text)
+
+# AFTER: Using Parameter Store
+DB_PASSWORD=$(aws ssm get-parameter \
+  --name "/tf-playground/all/db-password" \
+  --with-decryption \
+  --query 'Parameter.Value' --output text)
+```
+
+## Technical Insights Gained
+
+### Why KMS Permissions Matter
+Initially, I questioned why we needed KMS permissions for Parameter Store. The answer: SSM Parameter Store SecureString parameters are encrypted at rest using KMS. The condition `"kms:ViaService" = "ssm.amazonaws.com"` ensures decryption only happens through SSM, not direct KMS calls - a crucial security boundary.
+
+### The "Graceful Failure" Misconception
+The code claimed to "fail gracefully" when SSH keys were missing, but it actually didn't:
+- Terraform data sources without `count` conditions always execute
+- Missing secrets cause immediate Terraform failures
+- True graceful handling requires conditional resource creation
+
+## Business Impact
+
+### Cost Savings
+- Eliminated 4 Secrets Manager secrets: **$1.60/month saved**
+- Small win, but it adds up across multiple projects
+
+### Security Improvements
+- **Reduced attack surface**: No SSH keys to steal or leak
+- **Better audit trail**: Session Manager logs all access
+- **No key rotation needed**: IAM handles authentication
+
+### Developer Experience
+- **Simpler onboarding**: No SSH key distribution
+- **Consistent access**: Same method for all platforms
+- **Less configuration**: IAM roles handle everything
+
+## Lessons Learned
+
+1. **Technical debt accumulates silently** - Regular audits reveal hidden cruft
+2. **Migration paths matter** - Running parallel systems enabled safe transition
+3. **Documentation prevents regression** - Clear comments explain why things were removed
+4. **Modern AWS services eliminate complexity** - Session Manager > SSH keys
+
+## What's Next
+
+This cleanup is part of a larger initiative to position terraform-playground as both a learning playground AND a shared services hub. Next steps include:
+
+- Standardizing all projects on Parameter Store
+- Implementing automated secret rotation
+- Creating a service catalog for common patterns
+
+## Code Samples & References
+
+- [Full Migration PR](#) <!-- Link to GitHub PR -->
+- [terraform-playground Repository](https://github.com/KajiMaster/terraform-playground)
+- [AWS Session Manager Documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html)
+
+---
+
+*This infrastructure modernization reduced complexity while improving security. Sometimes the best code is the code you delete.*

--- a/docs/project-ideas/hugo-voice-mcp-origin-statement.md
+++ b/docs/project-ideas/hugo-voice-mcp-origin-statement.md
@@ -1,0 +1,207 @@
+# Project Origin Statement: Hugo Voice MCP
+
+**Date**: 2025-08-29  
+**Status**: Conceptual  
+**Type**: Developer Tool / Content Enhancement  
+
+## Problem Statement
+
+As I integrate AI assistance into my documentation workflow, I face a critical challenge: maintaining my authentic writing voice while leveraging AI's efficiency. Generated content often feels sterile, corporate, or "obviously AI" - which undermines the personal connection in portfolio pieces meant to showcase MY engineering journey.
+
+## Vision
+
+Create an MCP server that acts as a "voice guardian" for my Hugo portfolio site, learning from my approved writing samples to ensure all content - whether human or AI-assisted - maintains my authentic voice and technical communication style.
+
+## Core Concept
+
+### The MCP Server Would:
+
+1. **Learn My Voice**
+   - Analyze approved portfolio posts to understand my writing patterns
+   - Identify my common phrases, technical explanations, and storytelling style
+   - Build a profile of my preferred terminology and sentence structures
+
+2. **Review & Score Content**
+   - Rate new content on "authenticity score" (how much it sounds like me)
+   - Flag obvious AI patterns I typically reject
+   - Suggest rewrites that better match my voice
+
+3. **Integrate with Content Pipeline**
+   - Pre-publication review via MCP API
+   - Real-time suggestions during writing
+   - Batch processing for documentation migrations
+
+## Technical Architecture Ideas
+
+### MCP Server Components
+
+```yaml
+hugo-voice-mcp/
+├── server/
+│   ├── voice_analyzer.py      # Learns from approved content
+│   ├── style_scorer.py        # Rates content authenticity
+│   ├── rewrite_engine.py      # Suggests voice-matched alternatives
+│   └── mcp_interface.py       # MCP protocol implementation
+├── training_data/
+│   ├── approved/              # My approved writing samples
+│   ├── rejected/              # AI-generated content I've rejected
+│   └── patterns.json          # Learned style patterns
+├── hugo_integration/
+│   ├── pre_commit_hook.sh     # Check content before commit
+│   └── github_action.yml      # CI/CD integration
+└── tools/
+    ├── bulk_analyzer.py       # Analyze existing portfolio
+    └── voice_report.py        # Generate style insights
+```
+
+### How It Would Work
+
+1. **Training Phase**
+   ```python
+   # Pseudo-code concept
+   class VoiceAnalyzer:
+       def learn_from_approved(self, content):
+           # Extract patterns like:
+           # - Sentence length distribution
+           # - Technical term usage
+           # - Storytelling structures
+           # - Problem-solution narrative flow
+           # - Personal pronoun usage
+           # - Humor/casual language frequency
+   ```
+
+2. **Analysis Phase**
+   ```python
+   class StyleScorer:
+       def score_authenticity(self, new_content):
+           return {
+               "overall_score": 0.85,
+               "flags": [
+                   "Overly formal tone in paragraph 3",
+                   "Missing personal insight section",
+                   "Technical explanation too generic"
+               ],
+               "suggestions": [...]
+           }
+   ```
+
+3. **Integration with Claude/AI Tools**
+   - AI generates initial draft
+   - MCP server reviews and scores
+   - Suggests rewrites for low-scoring sections
+   - Learn from my accept/reject decisions
+
+## Unique Value Propositions
+
+### For My Portfolio
+- **Consistency**: All content maintains my voice, regardless of origin
+- **Authenticity**: Readers get genuine personality, not corporate speak
+- **Efficiency**: AI assistance without sacrificing personal touch
+
+### For the Broader Community
+- Could become a tool other developers use for their portfolios
+- Open-source contribution to the MCP ecosystem
+- Novel approach to the "AI detection" problem - embrace and improve rather than hide
+
+## Success Metrics
+
+1. **Voice Consistency Score**: 90%+ match across all portfolio content
+2. **Time Saved**: 50% reduction in editing AI-generated drafts
+3. **Reader Engagement**: Increased time on site (authentic content resonates)
+4. **Developer Adoption**: Other devs using it for their portfolios
+
+## Implementation Phases
+
+### Phase 1: Research & Prototype
+- Study existing style analysis tools
+- Build basic pattern extraction from my current portfolio
+- Create simple scoring algorithm
+
+### Phase 2: MCP Server Development
+- Implement MCP protocol
+- Build core voice analysis engine
+- Create basic Hugo integration
+
+### Phase 3: Training & Refinement
+- Feed approved/rejected content pairs
+- Refine scoring algorithms
+- Build rewrite suggestion engine
+
+### Phase 4: Full Integration
+- GitHub Actions workflow
+- Pre-commit hooks
+- Real-time editor integration
+
+## Open Questions
+
+1. **Training Data Volume**: How many writing samples needed for accurate voice modeling?
+2. **Pattern Complexity**: Can we capture subtle style elements like humor timing?
+3. **Evolution Handling**: How does the system adapt as my writing style evolves?
+4. **Privacy**: Should learned patterns be shareable or strictly personal?
+
+## Potential Challenges
+
+- **Overfitting**: System might become too restrictive, rejecting valid evolution
+- **Context Awareness**: Different content types need different voices (technical vs narrative)
+- **Performance**: Real-time analysis might slow down writing workflow
+- **Maintenance**: Keeping training data current and relevant
+
+## Related Projects to Research
+
+- GitHub Copilot's context awareness
+- Grammarly's tone detection
+- OpenAI's fine-tuning approaches
+- Existing MCP servers for content manipulation
+
+## Next Steps
+
+If pursuing this project:
+
+1. **Create dedicated repository**: `hugo-voice-mcp`
+2. **Analyze current portfolio**: Extract baseline voice patterns
+3. **Build proof of concept**: Simple scorer for one metric (e.g., sentence length)
+4. **Test with real content**: Score this very document!
+5. **Iterate based on results**: Refine what "sounds like me" means
+
+## Why This Matters
+
+This isn't just about vanity or "sounding right" - it's about solving a real problem in the age of AI assistance. As developers, we want to leverage AI for efficiency, but our portfolios are personal brands. They need to reflect WHO we are, not just WHAT we've built. This MCP server could bridge that gap, making AI a true collaborator that enhances rather than replaces our voice.
+
+## Connection to Current Work
+
+This idea emerged from the terraform-playground documentation work, where I noticed:
+- AI-generated documentation often missed my problem-solving narrative style
+- Technical explanations lacked my specific teaching approach
+- The "voice" difference was immediately noticeable
+
+This tool would ensure that as I document projects like terraform-playground, the stories remain authentically mine while benefiting from AI's organizational and comprehensive capabilities.
+
+---
+
+*This origin statement itself could become training data - it's written in my voice, explaining my idea, in my typical problem-solution-vision format.*
+
+## Repository Structure Vision
+
+```
+~/projects/
+├── virtualexponent-website/      # Hugo site (could move up one level)
+│   ├── content/
+│   │   └── portfolio/           # Auto-populated from project docs
+│   └── mcp-integrations/
+│       └── hugo-voice-mcp/      # The MCP server
+├── terraform-playground/
+│   └── docs/
+│       └── portfolio/           # Project-specific portfolio entries
+├── curriculum-designer/
+│   └── docs/
+│       └── portfolio/           # Project-specific portfolio entries
+└── project-glish/
+    └── docs/
+        └── portfolio/           # Project-specific portfolio entries
+```
+
+The Hugo site could indeed live at a parent level, scanning down into each project's portfolio folder, while the MCP server ensures everything maintains your voice.
+
+---
+
+**Decision Point**: Is this worth pursuing as a standalone project, or should it remain a "someday maybe" idea?

--- a/docs/secrets-cleanup-migration.md
+++ b/docs/secrets-cleanup-migration.md
@@ -1,0 +1,149 @@
+# Secrets Cleanup Migration
+
+**Date**: 2025-08-29  
+**Status**: Completed  
+**Impact**: Low - No service disruption expected
+
+## Overview
+
+This migration removes deprecated SSH keys and consolidates database password management from AWS Secrets Manager to AWS Systems Manager Parameter Store.
+
+## Background
+
+terraform-playground has evolved from using SSH keys for instance access to using AWS Systems Manager Session Manager. Additionally, database passwords were duplicated between Secrets Manager and Parameter Store. This cleanup removes technical debt and simplifies secrets management.
+
+## Changes Made
+
+### 1. SSH Key Removal
+
+**Removed References:**
+- `environments/terraform/main.tf`: Removed SSH key data sources
+- `modules/compute/asg/main.tf`: Removed SSH key IAM permissions
+
+**Why SSH Keys Are No Longer Needed:**
+- **EC2/ASG**: Uses SSM Session Manager (`aws ssm start-session --target <instance-id>`)
+- **ECS Fargate**: Serverless - no instances to SSH into, use ECS Exec
+- **EKS**: Use `kubectl exec` for pods, SSM for nodes if needed
+
+### 2. Database Password Consolidation
+
+**Migration Path:**
+- FROM: `/tf-playground/all/db-pword` (Secrets Manager)
+- TO: `/tf-playground/all/db-password` (Parameter Store)
+
+**Files Updated:**
+- `modules/compute/asg/main.tf`: Updated IAM policy from Secrets Manager to Parameter Store
+- `modules/compute/asg/templates/user_data.sh`: Updated to use SSM client instead of Secrets Manager
+- `app/main.py`: Updated parameter name
+- All scripts in `/scripts/` directory
+- Bootstrap scripts: `ecs-database-bootstrap.sh`, `eks-database-bootstrap.sh`
+
+### 3. IAM Permission Updates
+
+**Old Permissions (Removed):**
+```json
+{
+  "Action": ["secretsmanager:GetSecretValue"],
+  "Resource": [
+    "arn:aws:secretsmanager:*:*:secret:/tf-playground/*/db-pword*",
+    "arn:aws:secretsmanager:*:*:secret:/tf-playground/all/ssh-key*"
+  ]
+}
+```
+
+**New Permissions (Added):**
+```json
+{
+  "Action": [
+    "ssm:GetParameter",
+    "ssm:GetParameters",
+    "ssm:GetParametersByPath"
+  ],
+  "Resource": [
+    "arn:aws:ssm:*:*:parameter/tf-playground/all/db-password",
+    "arn:aws:ssm:*:*:parameter/tf-playground/${environment}/*"
+  ]
+},
+{
+  "Action": ["kms:Decrypt"],
+  "Resource": "*",
+  "Condition": {
+    "StringEquals": {
+      "kms:ViaService": "ssm.${region}.amazonaws.com"
+    }
+  }
+}
+```
+
+**Note on KMS Permissions:** The KMS decrypt permission is required because SSM Parameter Store SecureString parameters are encrypted at rest using AWS KMS. The condition ensures decryption only happens through SSM service calls.
+
+## AWS Resources to Delete
+
+After applying these changes, the following AWS Secrets Manager secrets can be deleted:
+
+```bash
+# List secrets that can be deleted
+aws secretsmanager list-secrets --region us-east-2 --filters Key=name,Values=/tf-playground
+
+# Delete deprecated secrets (after verification)
+aws secretsmanager delete-secret --secret-id /tf-playground/all/db-pword --force-delete-without-recovery
+aws secretsmanager delete-secret --secret-id /tf-playground/all/ssh-key --force-delete-without-recovery
+aws secretsmanager delete-secret --secret-id /tf-playground/all/ssh-key-public --force-delete-without-recovery
+aws secretsmanager delete-secret --secret-id /tf-playground/dev/database/credentials --force-delete-without-recovery
+```
+
+## Rollback Plan
+
+If issues occur, the changes can be reverted by:
+1. Reverting the git commits
+2. Re-applying Terraform
+3. Restoring the Secrets Manager secrets from AWS backup (if within recovery window)
+
+## Verification Steps
+
+1. **Test Parameter Store Access:**
+```bash
+aws ssm get-parameter --name /tf-playground/all/db-password --with-decryption --region us-east-2
+```
+
+2. **Test Instance Access (no SSH needed):**
+```bash
+# Get instance ID
+INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Environment,Values=staging" --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+# Connect via Session Manager
+aws ssm start-session --target $INSTANCE_ID
+```
+
+3. **Verify Application Connectivity:**
+```bash
+# Test that applications can still connect to database
+curl http://your-alb-url/health
+```
+
+## Benefits
+
+1. **Simplified Secrets Management**: Single source of truth in Parameter Store
+2. **Improved Security**: No SSH keys to manage, rotate, or potentially leak
+3. **Cost Reduction**: Fewer Secrets Manager secrets (charged per secret per month)
+4. **Better Access Control**: IAM-based access via Session Manager is more auditable
+5. **Reduced Attack Surface**: No SSH ports exposed, no key distribution needed
+
+## Lessons Learned
+
+1. **Gradual Migration Works**: Running both systems in parallel allowed safe migration
+2. **Parameter Store vs Secrets Manager**: Parameter Store is sufficient for simple key-value secrets
+3. **Session Manager Superiority**: SSM Session Manager eliminates SSH key management complexity
+4. **Documentation is Critical**: Clear migration docs help future maintainers understand the evolution
+
+## Next Steps
+
+1. Monitor applications for any authentication issues
+2. Delete the Secrets Manager secrets after 7-day observation period
+3. Consider migrating other secrets to Parameter Store where appropriate
+4. Update project documentation to reflect new access patterns
+
+---
+
+*Migration completed by: terraform-playground maintainer*  
+*Review status: Pending production validation*

--- a/environments/global/main.tf
+++ b/environments/global/main.tf
@@ -72,4 +72,28 @@ module "ecr" {
   tags = {
     Purpose = "shared-container-registry"
   }
+}
+
+# Shared SSM Parameter for Claude API Key
+# Used by multiple projects for GitHub Actions Claude Code reviews
+resource "aws_ssm_parameter" "claude_api_key" {
+  name        = "/global/claude-code/api-key"
+  type        = "SecureString"
+  description = "Anthropic API key for Claude Code reviews across all projects"
+  
+  # Placeholder value - update this after creation via AWS CLI or Console
+  value = "PLACEHOLDER_UPDATE_VIA_AWS_CONSOLE"
+
+  # Ignore changes to the value to preserve the existing secret
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = {
+    Name        = "claude-code-api-key"
+    Environment = "global"
+    Purpose     = "github-actions-claude-reviews"
+    ManagedBy   = "terraform"
+    Project     = "shared-infrastructure"
+  }
 } 

--- a/environments/terraform/ecs-database-bootstrap.sh
+++ b/environments/terraform/ecs-database-bootstrap.sh
@@ -131,7 +131,7 @@ fi
 echo "✅ Found ECS task: $TASK_ARN"
 
 echo "Getting database password from Parameter Store..."
-DB_PASSWORD=$(aws ssm get-parameter --name "/tf-playground/all/db-pword" --region "$AWS_REGION" --with-decryption --query Parameter.Value --output text)
+DB_PASSWORD=$(aws ssm get-parameter --name "/tf-playground/all/db-password" --region "$AWS_REGION" --with-decryption --query Parameter.Value --output text)
 
 if [ -z "$DB_PASSWORD" ]; then
     echo "❌ Error: Could not retrieve database password from Parameter Store"

--- a/environments/terraform/eks-database-bootstrap.sh
+++ b/environments/terraform/eks-database-bootstrap.sh
@@ -151,7 +151,7 @@ fi
 echo "✅ Found Flask app pod: $POD_NAME"
 
 echo "Getting database password from Parameter Store..."
-DB_PASSWORD=$(aws ssm get-parameter --name "/tf-playground/all/db-pword" --region "$AWS_REGION" --with-decryption --query Parameter.Value --output text)
+DB_PASSWORD=$(aws ssm get-parameter --name "/tf-playground/all/db-password" --region "$AWS_REGION" --with-decryption --query Parameter.Value --output text)
 
 if [ -z "$DB_PASSWORD" ]; then
     echo "❌ Error: Could not retrieve database password from Parameter Store"

--- a/environments/terraform/outputs.tf
+++ b/environments/terraform/outputs.tf
@@ -19,22 +19,10 @@ output "alb_zone_id" {
 }
 
 # SSH Key Outputs
-output "ssh_key_name" {
-  description = "Name of the SSH key pair"
-  value       = length(aws_key_pair.environment_key) > 0 ? aws_key_pair.environment_key[0].key_name : null
-}
+# SSH outputs removed - using SSM Session Manager for access
+# Connect to instances via: aws ssm start-session --target <instance-id>
 
-output "ssh_private_key" {
-  description = "Private key for SSH access (sensitive)"
-  value       = data.aws_secretsmanager_secret_version.ssh_private.secret_string
-  sensitive   = true
-}
-
-output "ssh_public_key" {
-  description = "Public key content"
-  value       = length(data.aws_secretsmanager_secret_version.ssh_public) > 0 ? data.aws_secretsmanager_secret_version.ssh_public[0].secret_string : null
-  sensitive   = true
-}
+# SSH public key output removed - using SSM Session Manager for access
 
 # Blue Auto Scaling Group Outputs
 output "blue_asg_id" {
@@ -232,7 +220,7 @@ output "environment_summary" {
     blue_asg_name     = var.enable_asg ? module.blue_asg[0].asg_name : null
     green_asg_name    = var.enable_asg ? module.green_asg[0].asg_name : null
     database_endpoint = var.enable_rds ? module.database[0].db_instance_endpoint : "serverless-architecture"
-    ssh_key_name      = length(aws_key_pair.environment_key) > 0 ? aws_key_pair.environment_key[0].key_name : null
+    # ssh_key_name removed - using SSM Session Manager
   }
 }
 

--- a/modules/compute/asg/templates/user_data.sh
+++ b/modules/compute/asg/templates/user_data.sh
@@ -67,13 +67,13 @@ def get_db_password():
         region_response = requests.get('http://169.254.169.254/latest/meta-data/placement/region', timeout=5)
         region = region_response.text if region_response.status_code == 200 else 'us-east-2'
         
-        client = boto3.client('secretsmanager', region_name=region)
-        # Use centralized database password secret
-        secret_name = '/tf-playground/all/db-pword'
-        response = client.get_secret_value(SecretId=secret_name)
+        client = boto3.client('ssm', region_name=region)
+        # Use centralized database password parameter
+        parameter_name = '/tf-playground/all/db-password'
+        response = client.get_parameter(Name=parameter_name, WithDecryption=True)
         
-        # The password is stored as a plain string, not JSON
-        return response['SecretString']
+        # Return the parameter value
+        return response['Parameter']['Value']
     except Exception as e:
         print(f"Failed to get password from Secrets Manager: {e}")
         return None  # No fallback - let the application handle the error

--- a/modules/oidc/main.tf
+++ b/modules/oidc/main.tf
@@ -212,15 +212,6 @@ resource "aws_iam_role_policy" "terraform_permissions" {
           "arn:aws:iam::*:role/AWSServiceRoleForAmazonEKSNodegroup"
         ]
       },
-      # KMS permissions for AWS managed keys (limited scope)
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Decrypt",
-          "kms:DescribeKey"
-        ]
-        Resource = "*"
-      },
       # Secrets Manager permissions
       {
         Effect = "Allow"
@@ -229,13 +220,57 @@ resource "aws_iam_role_policy" "terraform_permissions" {
         ]
         Resource = "*"
       },
-      # SSM permissions for automation
+      # SSM permissions for Parameter Store access
       {
         Effect = "Allow"
         Action = [
-          "ssm:*"
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParameterHistory",
+          "ssm:GetParametersByPath",
+          "ssm:DescribeParameters",
+          "ssm:PutParameter",
+          "ssm:DeleteParameter",
+          "ssm:DeleteParameters",
+          "ssm:AddTagsToResource",
+          "ssm:RemoveTagsFromResource",
+          "ssm:ListTagsForResource"
+        ]
+        Resource = [
+          "arn:aws:ssm:${var.aws_region}:*:parameter/global/*",
+          "arn:aws:ssm:${var.aws_region}:*:parameter/${var.environment}/*"
+        ]
+      },
+      # SSM permissions for session manager and other SSM operations
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:StartSession",
+          "ssm:TerminateSession",
+          "ssm:ResumeSession",
+          "ssm:DescribeSessions",
+          "ssm:GetConnectionStatus",
+          "ssm:DescribeInstanceInformation",
+          "ssm:DescribeInstanceProperties",
+          "ssm:SendCommand",
+          "ssm:ListCommandInvocations",
+          "ssm:GetCommandInvocation"
         ]
         Resource = "*"
+      },
+      # KMS permissions for decrypting SSM SecureString parameters
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "ssm.${var.aws_region}.amazonaws.com"
+          }
+        }
       },
       # CloudWatch permissions for monitoring and alarms
       {

--- a/modules/oidc/main.tf
+++ b/modules/oidc/main.tf
@@ -238,7 +238,8 @@ resource "aws_iam_role_policy" "terraform_permissions" {
         ]
         Resource = [
           "arn:aws:ssm:${var.aws_region}:*:parameter/global/*",
-          "arn:aws:ssm:${var.aws_region}:*:parameter/${var.environment}/*"
+          "arn:aws:ssm:${var.aws_region}:*:parameter/${var.environment}/*",
+          "arn:aws:ssm:${var.aws_region}:*:parameter/tf-playground/*"
         ]
       },
       # SSM permissions for session manager and other SSM operations

--- a/scripts/clear-production-contacts.sh
+++ b/scripts/clear-production-contacts.sh
@@ -98,7 +98,7 @@ print_status "Database user: $DB_USER"
 # Get database password from Parameter Store
 print_info "Getting database password from Parameter Store..."
 DB_PASSWORD=$(aws ssm get-parameter \
-    --name "/tf-playground/all/db-pword" \
+    --name "/tf-playground/all/db-password" \
     --region "$AWS_REGION" \
     --with-decryption \
     --query 'Parameter.Value' \

--- a/scripts/clear-production-db.sh
+++ b/scripts/clear-production-db.sh
@@ -84,7 +84,7 @@ print_status "Database name: $DB_NAME"
 # Get database password from Parameter Store
 print_info "Getting database password from Parameter Store..."
 DB_PASSWORD=$(aws ssm get-parameter \
-    --name "/tf-playground/all/db-pword" \
+    --name "/tf-playground/all/db-password" \
     --region "$AWS_REGION" \
     --with-decryption \
     --query 'Parameter.Value' \

--- a/scripts/connect-production-db.sh
+++ b/scripts/connect-production-db.sh
@@ -98,7 +98,7 @@ print_status "Database user: $DB_USER"
 # Get database password from Parameter Store
 print_info "Getting database password from Parameter Store..."
 DB_PASSWORD=$(aws ssm get-parameter \
-    --name "/tf-playground/all/db-pword" \
+    --name "/tf-playground/all/db-password" \
     --region "$AWS_REGION" \
     --with-decryption \
     --query 'Parameter.Value' \

--- a/scripts/prime-database-ecs.sh
+++ b/scripts/prime-database-ecs.sh
@@ -57,8 +57,8 @@ DB_ENDPOINT=$(terraform output -raw database_endpoint)
 DB_NAME=$(terraform output -raw database_name)
 DB_USER="tfplayground_user"
 
-# Get database password from Secrets Manager
-DB_PASSWORD=$(aws secretsmanager get-secret-value --secret-id "/tf-playground/all/db-pword" --query 'SecretString' --output text)
+# Get database password from Parameter Store
+DB_PASSWORD=$(aws ssm get-parameter --name "/tf-playground/all/db-password" --with-decryption --query 'Parameter.Value' --output text)
 
 print_status "Database endpoint: $DB_ENDPOINT"
 print_status "Database name: $DB_NAME"


### PR DESCRIPTION
## Summary
- Established terraform-playground as shared services hub for GitHub Actions OIDC and secrets
- Added `/global/claude-code/api-key` SSM parameter for Claude Code reviews across projects
- Completed migration from SSH keys to SSM Session Manager across all platforms
- Consolidated database passwords from Secrets Manager to Parameter Store
- Updated IAM permissions for proper Parameter Store access with KMS decryption

## Breaking Changes
- SSH key outputs removed (replaced by SSM Session Manager)
- Database scripts now use `/tf-playground/all/db-password` from Parameter Store
- Secrets Manager references removed from IAM policies

## Benefits
- 🔐 Reduced attack surface (no SSH keys to manage or leak)
- 💰 Lower costs ($1.60/month Secrets Manager savings)
- 🏗️ Simplified access patterns (SSM Session Manager + ECS Exec)
- 📊 Centralized secrets management in Parameter Store
- 🌐 Shared services architecture for cross-project resources

## Test Plan
- [x] terraform plan passes for ECS staging configuration
- [x] SSM parameter `/global/claude-code/api-key` created and accessible
- [x] No broken references to removed SSH resources
- [ ] Deploy ECS staging environment via GitHub Actions
- [ ] Verify application can access database via Parameter Store
- [ ] Test Claude Code review workflow in other projects

## Architecture Notes
This establishes terraform-playground as both a learning playground AND shared services hub, providing centralized OIDC authentication and secrets management for dependent projects like virtualexponent-website and curriculum-designer.